### PR TITLE
configの設定とパッケージの追加

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,7 @@
+[web]
+port = 8080
+logfile = webapp.log
+
+[db]
+driver = sqlite3
+name = webapp.sql

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"log"
+
+	"gopkg.in/go-ini/ini.v1"
+)
+
+type ConfigList struct {
+	Port      string
+	SQLDriver string
+	DbName    string
+	LogFile   string
+}
+
+var Config ConfigList
+
+func init() {
+	LoadConfig()
+}
+
+func LoadConfig() {
+	cfg, err := ini.Load("config.ini")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	Config = ConfigList{
+		Port:      cfg.Section("web").Key("port").MustString("8080"),
+		SQLDriver: cfg.Section("db").Key("driver").String(),
+		DbName:    cfg.Section("db").Key("name").String(),
+		LogFile:   cfg.Section("web").Key("logfile").String(),
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module torelog_bygolang
+
+go 1.18
+
+require gopkg.in/go-ini/ini.v1 v1.66.4
+
+require github.com/stretchr/testify v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/go-ini/ini.v1 v1.66.4 h1:D+Pf2zDbMRIu5jqvMKF4ienECDJiU83376HNqnHgw50=
+gopkg.in/go-ini/ini.v1 v1.66.4/go.mod h1:M74/hG4RTwbkZyTEZ9iQwM4v6dFD4u6QBjoqT/pM8Kg=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"torelog_bygolang/config"
+)
+
+func main() {
+	fmt.Println(config.Config.Port)
+	fmt.Println(config.Config.SQLDriver)
+	fmt.Println(config.Config.DbName)
+	fmt.Println(config.Config.LogFile)
+}


### PR DESCRIPTION
## 変更の概要

* config周りの設定をした
* main.goが走る際にconfigで設定した処理が走るようにした
* パッケージの追加(go.mod・go.sumファイル)

## なぜこの変更をするのか

* ローカル開発を行うためのポートやDBのドライバーなどの設定をする必要があるため

## やったこと

* [x] config > config.goの作成
* [x] config.iniの作成
* [x] main.goの作成
* [x] go.modの作成
* [x] go.sumの作成

## 変更内容

* 上記フォルダとファイルの作成

## 影響範囲

* 今後の全開発工程

## どうやるのか
### config周り
* config.goにてPort・SQLDriver・DbName・LogFileの構造体を決め、これらの中身をconfig.iniから取得するLoadConfig()を準備
* main.goでLoadConfig()を受け取り上記の中身が認識されるようにmain()を組む

### パッケージ周り
* go mod init コマンド
* go mod tidy コマンド

## 課題

* 特になし

## 備考

* 特になし