### PR TITLE
herokuにデプロイするためにpostgresqlで動作するようにする

### DIFF
--- a/app/controllers/server.go
+++ b/app/controllers/server.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
 	"strconv"
 	"text/template"
@@ -69,5 +70,7 @@ func StartMainServer() (err error) {
 	http.HandleFunc("/trainingLogs/edit/", parseURL(trainingLogEdit))
 	http.HandleFunc("/trainingLogs/update/", parseURL(trainingLogUpdate))
 	http.HandleFunc("/trainingLogs/delete/", parseURL(trainingLogDelete))
-	return http.ListenAndServe(":"+config.Config.Port, nil)
+
+	port := os.Getenv("PORT")
+	return http.ListenAndServe(":"+port, nil)
 }

--- a/app/models/base.go
+++ b/app/models/base.go
@@ -5,9 +5,11 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"os"
 	"torelog_bygolang/config"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -15,47 +17,57 @@ var Db *sql.DB
 
 var err error
 
-const (
-	tableNameUser        = "users"
-	tableNameTrainingLog = "trainingLogs"
-	tableNameSession     = "sessions"
-)
+// const (
+// 	tableNameUser        = "users"
+// 	tableNameTrainingLog = "trainingLogs"
+// 	tableNameSession     = "sessions"
+// )
 
 func init() {
-	Db, err = sql.Open(config.Config.SQLDriver, config.Config.DbName)
 
+	url := os.Getenv("DATABASE_URL")
+	connection, _ := pq.ParseURL(url)
+	connection += "sslmode=require"
+	Db, err = sql.Open(config.Config.SQLDriver, connection)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	cmdU := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s(
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
-		uuid STRING NOT NULL UNIQUE,
-		name STRING,
-		email STRING,
-		password STRING,
-		created_at DATETIME)`, tableNameUser)
+	// sqlite向けの処理
+	// Db, err = sql.Open(config.Config.SQLDriver, config.Config.DbName)
 
-	Db.Exec(cmdU)
+	// if err != nil {
+	// 	log.Fatalln(err)
+	// }
 
-	cmdT := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s(
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
-		content TEXT,
-		satisfaction STRING,
-		weather STRING,
-		user_id INTEGER,
-		created_at DATETIME)`, tableNameTrainingLog)
+	// cmdU := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s(
+	// 	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	// 	uuid STRING NOT NULL UNIQUE,
+	// 	name STRING,
+	// 	email STRING,
+	// 	password STRING,
+	// 	created_at DATETIME)`, tableNameUser)
 
-	Db.Exec(cmdT)
+	// Db.Exec(cmdU)
 
-	cmdS := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s(
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
-		uuid STRING NOT NULL UNIQUE,
-		email STRING,
-		user_id INTEGER,
-		created_at DATETIME)`, tableNameSession)
+	// cmdT := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s(
+	// 	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	// 	content TEXT,
+	// 	satisfaction STRING,
+	// 	weather STRING,
+	// 	user_id INTEGER,
+	// 	created_at DATETIME)`, tableNameTrainingLog)
 
-	Db.Exec(cmdS)
+	// Db.Exec(cmdT)
+
+	// cmdS := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s(
+	// 	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	// 	uuid STRING NOT NULL UNIQUE,
+	// 	email STRING,
+	// 	user_id INTEGER,
+	// 	created_at DATETIME)`, tableNameSession)
+
+	// Db.Exec(cmdS)
 
 }
 

--- a/app/models/trainingLogs.go
+++ b/app/models/trainingLogs.go
@@ -21,7 +21,7 @@ func (u *User) CreateTrainingLog(content string, satisfaction string, weather st
 		satisfaction,
 		weather,
 		user_id,
-		created_at) values (?, ?, ?, ?, ?)`
+		created_at) values ($1, $2, $3, $4, $5)`
 
 	// 書式指定
 	const format = "2006-01-02 15:04:05"
@@ -37,7 +37,7 @@ func (u *User) CreateTrainingLog(content string, satisfaction string, weather st
 
 // トレーニングログ情報を取得（単数）
 func GetTrainingLog(id int) (trainingLog TrainingLog, err error) {
-	cmd := `select id, content, satisfaction, weather, user_id, created_at from trainingLogs where id = ?`
+	cmd := `select id, content, satisfaction, weather, user_id, created_at from trainingLogs where id = $1`
 	trainingLog = TrainingLog{}
 	err = Db.QueryRow(cmd, id).Scan(
 		&trainingLog.ID,
@@ -82,7 +82,7 @@ func GetTrainingLogs() (trainingLogs []TrainingLog, err error) {
 
 // ユーザーIDで絞り込んでトレーニングログ情報を取得
 func (u *User) GetTrainingLogsByUser() (trainingLogs []TrainingLog, err error) {
-	cmd := `select id, content, satisfaction, weather, user_id, created_at from trainingLogs where user_id = ?`
+	cmd := `select id, content, satisfaction, weather, user_id, created_at from trainingLogs where user_id = $1`
 	rows, err := Db.Query(cmd, u.ID)
 	if err != nil {
 		log.Fatalln(err)
@@ -110,7 +110,7 @@ func (u *User) GetTrainingLogsByUser() (trainingLogs []TrainingLog, err error) {
 
 // トレーニングログ情報を更新
 func (t *TrainingLog) UpdateTrainingLog() (err error) {
-	cmd := `update trainingLogs set content = ?, satisfaction = ?, weather = ?, user_id =? where id = ?`
+	cmd := `update trainingLogs set content = $1, satisfaction = $2, weather = $3, user_id =$4 where id = $5`
 	_, err = Db.Exec(cmd, t.Content, t.Satisfaction, t.Weather, t.UserID, t.ID)
 	if err != nil {
 		log.Fatalln(err)
@@ -121,7 +121,7 @@ func (t *TrainingLog) UpdateTrainingLog() (err error) {
 
 // トレーニングログ情報を削除
 func (t *TrainingLog) DeleteTrainingLog() (err error) {
-	cmd := `delete from trainingLogs where id = ?`
+	cmd := `delete from trainingLogs where id = $1`
 	_, err = Db.Exec(cmd, t.ID)
 	if err != nil {
 		log.Fatalln(err)

--- a/app/models/users.go
+++ b/app/models/users.go
@@ -30,7 +30,7 @@ func (u *User) CreateUser() (err error) {
 		name,
 		email,
 		password,
-		created_at) values (?, ?, ?, ?, ?)`
+		created_at) values ($1, $2, $3, $4, $5)`
 
 	_, err = Db.Exec(cmd,
 		createUUID(),
@@ -49,7 +49,7 @@ func (u *User) CreateUser() (err error) {
 // ユーザー情報を取得
 func GetUser(id int) (user User, err error) {
 	user = User{}
-	cmd := `select id, uuid, name, email, password, created_at from users where id = ?`
+	cmd := `select id, uuid, name, email, password, created_at from users where id = $1`
 	err = Db.QueryRow(cmd, id).Scan(
 		&user.ID,
 		&user.UUID,
@@ -64,7 +64,7 @@ func GetUser(id int) (user User, err error) {
 
 // ユーザー情報を更新
 func (u *User) UpdateUser() (err error) {
-	cmd := `update users set name = ?, email = ? where id = ?`
+	cmd := `update users set name = $1, email = $2 where id = $3`
 	_, err = Db.Exec(cmd, u.Name, u.Email, u.ID)
 	if err != nil {
 		log.Fatalln(err)
@@ -75,7 +75,7 @@ func (u *User) UpdateUser() (err error) {
 
 // ユーザー情報を削除
 func (u *User) DeleteUser() (err error) {
-	cmd := `delete from users where id = ?`
+	cmd := `delete from users where id = $1`
 	_, err = Db.Exec(cmd, u.ID)
 	if err != nil {
 		log.Fatalln(err)
@@ -86,7 +86,7 @@ func (u *User) DeleteUser() (err error) {
 // ログイン時にEmailからユーザー情報を取得する
 func GetUserByEmail(email string) (user User, err error) {
 	user = User{}
-	cmd := `select id, uuid, name, email, password, created_at from users where email = ?`
+	cmd := `select id, uuid, name, email, password, created_at from users where email = $1`
 	err = Db.QueryRow(cmd, email).Scan(
 		&user.ID,
 		&user.UUID,
@@ -105,13 +105,13 @@ func (u *User) CreateSession() (session Session, err error) {
 		uuid,
 		email,
 		user_id,
-		created_at) values (?, ?, ?, ?)`
+		created_at) values ($1, $2, $3, $4)`
 	Db.Exec(cmd1, createUUID(), u.Email, u.ID, time.Now())
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	cmd2 := `select id, uuid, email, user_id, created_at from sessions where user_id = ? and email = ?`
+	cmd2 := `select id, uuid, email, user_id, created_at from sessions where user_id = $1 and email = $2`
 	err = Db.QueryRow(cmd2, u.ID, u.Email).Scan(
 		&session.ID,
 		&session.UUID,
@@ -124,7 +124,7 @@ func (u *User) CreateSession() (session Session, err error) {
 
 // セッションが存在するかどうかチェックする
 func (sess *Session) CheckSession() (valid bool, err error) {
-	cmd := `select id, uuid, email, user_id, created_at from sessions where uuid = ?`
+	cmd := `select id, uuid, email, user_id, created_at from sessions where uuid = $1`
 	Db.QueryRow(cmd, sess.UUID).Scan(
 		&sess.ID,
 		&sess.UUID,
@@ -144,7 +144,7 @@ func (sess *Session) CheckSession() (valid bool, err error) {
 
 // セッションを削除すする
 func (sess *Session) DeleteSessionByUUID() (err error) {
-	cmd := `delete from sessions where uuid = ?`
+	cmd := `delete from sessions where uuid = $1`
 	_, err = Db.Exec(cmd, sess.UUID)
 	if err != nil {
 		log.Fatalln(err)
@@ -155,7 +155,7 @@ func (sess *Session) DeleteSessionByUUID() (err error) {
 // セッションで絞り込んでユーザー情報を取得する
 func (sess *Session) GetUserBySession() (user User, err error) {
 	user = User{}
-	cmd := `select id, uuid, name, email, created_at FROM users where id = ?`
+	cmd := `select id, uuid, name, email, created_at FROM users where id = $1`
 	err = Db.QueryRow(cmd, sess.UserID).Scan(
 		&user.ID,
 		&user.UUID,

--- a/config.ini
+++ b/config.ini
@@ -4,5 +4,5 @@ logfile = webapp.log
 static = app/views
 
 [db]
-driver = sqlite3
+driver = postgres
 name = webapp.sql

--- a/example.sql
+++ b/example.sql
@@ -1,0 +1,27 @@
+drop table sessions;
+drop table users;
+drop table todos;
+ 
+create table users (
+  id         serial primary key,
+  uuid       varchar(64) not null unique,
+  name       varchar(255),
+  email      varchar(255) not null unique,
+  password   varchar(255) not null,
+  created_at timestamp not null   
+);
+ 
+create table sessions (
+  id         serial primary key,
+  uuid       varchar(64) not null unique,
+  email      varchar(255),
+  user_id    integer references users(id),
+  created_at timestamp not null   
+);
+ 
+create table todos (
+  id         serial primary key,
+  content    text,
+  user_id    integer references users(id),
+  created_at timestamp not null       
+);

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require gopkg.in/go-ini/ini.v1 v1.66.4
 
 require (
 	github.com/google/uuid v1.3.0
+	github.com/lib/pq v1.10.6
 	github.com/mattn/go-sqlite3 v1.14.12
 	github.com/stretchr/testify v1.7.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/lib/pq v1.10.6 h1:jbk+ZieJ0D7EVGJYpL9QTz7/YW6UHbmdnZWYyK5cdBs=
+github.com/lib/pq v1.10.6/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mattn/go-sqlite3 v1.14.12 h1:TJ1bhYJPV44phC+IMu1u2K/i5RriLTPe+yc68XDJ1Z0=
 github.com/mattn/go-sqlite3 v1.14.12/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/procfile
+++ b/procfile
@@ -1,0 +1,1 @@
+web: torelog_bygolang


### PR DESCRIPTION
## 変更の概要

* herokuにデプロイするためにpostgresqlで動作するようにする

## なぜこの変更をするのか

* herokuにデプロイするため

## やったこと

* [x] トレーニングログに関するSQLをpostgres向けに調整：app > models > trainingLogs.go
* [x] ユーザーに関するSQLをpostgres向けに調整：app > models > users.go
* [x] ドライバとinit関数を調整：app > models > base.go
* [x] herokuにデータベースを用意するためのファイルを準備：example.sql
* [x] ポートを調整：app > controllers > server.go

## 変更内容

* 上記

## 影響範囲

* SQLに関わること
* ポートに関わること

## どうやるのか

* herokuにあげる

## 課題

* 特になし

## 備考

* 特になし